### PR TITLE
docs: admin interface plan on the Astro production baseline

### DIFF
--- a/plans/admin-interface-plan.md
+++ b/plans/admin-interface-plan.md
@@ -58,21 +58,22 @@ Staging specifics to get right:
 ### Step 0 — Cutover hygiene (this week)
 
 - [x] Merge `feature/astro` → `main` (`--no-ff`, empty diff verified).
-- [ ] Repoint the DO app components to `main` (dashboard — Gary). Verify a push to `main` triggers a deploy and the site is unchanged.
-- [ ] First commits on the admin branch: delete `.do/app.yaml`, move `robots.txt` to `public/`, add `@astrojs/sitemap`, untrack `tmp/`.
+- [x] Repoint the DO app components to `main` (dashboard — Gary).
+- [x] First commits on the admin branch (`feature/admin-cms`, PR #6): delete `.do/app.yaml`, move `robots.txt` to `public/`, add `@astrojs/sitemap`, untrack `tmp/`.
 - [ ] Delete `feature/astro` and `feature/zensical` **only after** the repoint is confirmed.
 
 ### Step 1 — CI before the admin gets keys
 
-- [ ] GitHub Actions on PRs + pushes to `main`: `npm ci && npm run build`, then the pytest/Playwright parity harness.
+- [x] GitHub Actions on PRs + pushes to `main`: `npm ci && npm run build`, then the pytest/Playwright parity harness (first run green: 402 passed, 6 skipped, ~90s).
 - [ ] Branch protection on `main` requiring the build check (harness advisory at first if it proves slow on content-only commits).
 
 ### Step 2 — Sveltia CMS integration
 
-- [ ] `public/admin/index.html` (loads Sveltia) + `public/admin/config.yml`.
-- [ ] Model the **services** collection mirroring the Zod schema: strings for `title`, `meta_description`, `hero_tag`, `hero_sub`; text for `lead`; list-of-object for `features` (`icon`, `text`) and `faqs`; objects for `home_card`, `cta`; markdown body. Expose `order`, `coming_soon`, `related_services` with clear labels. Plain-English field labels throughout.
+- [x] `/admin` shell (`src/pages/admin/index.astro`) + build-time generated `/admin/config.yml` (`config.yml.ts`; `CMS_BRANCH` selects the commit branch per environment, `CMS_AUTH_BASE_URL` wires the OAuth helper).
+- [x] Model the **services** collection mirroring the Zod schema: strings for `title`, `meta_description`, `hero_tag`, `hero_sub`; text for `lead`; list-of-object for `features` (`icon`, `text`) and `faqs`; objects for `home_card`, `cta`; markdown body. Expose `order`, `coming_soon`, `related_services` with clear labels. Plain-English field labels throughout.
 - [ ] GitHub OAuth App + `sveltia-cms-auth`; wire `base_url` in `config.yml`.
-- [ ] Stand up the staging DO app on the admin branch; walk the admin through login → edit → save → deploy → rollback once, together.
+- [x] Staging DO app live at https://securetours-staging-6i7a4.ondigitalocean.app (static-only, `CMS_BRANCH=feature/admin-cms` verified).
+- [ ] Walk the admin through login → edit → save → deploy → rollback once, together.
 
 ### Step 3 — Widen the editable surface (schema-first, incremental)
 

--- a/plans/admin-interface-plan.md
+++ b/plans/admin-interface-plan.md
@@ -1,115 +1,146 @@
-# Admin interface — review and plan
+# Admin interface — review and plan (build on the existing static site)
 
-**Date:** 2026-07-05
-**Scope:** How the company admin gets a safe content-editing interface, what is already in flight, what deployments look like today, and the sequenced steps to get there.
+**Date:** 2026-07-08
+**Decision context:** The Astro rewrite (PR #4) has been closed and will not be used. The plan below layers a safe content-editing interface **on top of the existing static HTML site on `main`** — no framework, no rewrite.
 
 ---
 
 ## 1. Where things stand today
 
-### Deployed state (production/staging)
+### Deployed state
 
-- **`main`** is the customer-approved static HTML prototype: 22 bespoke pages, duplicated nav/footer in every file, `js/translations.js` as the JS-injected content source, hand-maintained `sitemap.xml`. Deployed to DigitalOcean App Platform; staging at `securetours.staging-site.au`.
-- The DO app spec for the *current* static deployment is **not in the repo** — `main` has no `.do/app.yaml`. The live app configuration exists only in the DO dashboard (click-ops).
-- The contact form on `main` is **non-functional**: `js/main.js:47` still has the `FORMSPREE_FORM_ID` placeholder.
-- There is nothing an admin can safely edit here. Every content change means hand-editing HTML duplicated across ~22 files (plus `translations.js`), which is exactly the "blow up the site design" risk we want to remove.
+- `main` is the customer-approved static site: 22 standalone HTML pages, duplicated nav/footer per page, `css/style.css` design system, `js/main.js` + `js/translations.js`. Deployed to DigitalOcean App Platform; staging at `securetours.staging-site.au`.
+- The DO app spec is **not in the repo** — the live configuration exists only in the DO dashboard.
+- The contact form is **non-functional**: `js/main.js:47` still carries the `FORMSPREE_FORM_ID` placeholder.
+- No CI of any kind — nothing runs on push.
 
-### In flight: PR #4 — Astro rewrite (`feature/astro`, TOU-159)
+### The key finding: the site already has a content layer
 
-Open, mergeable-clean, 27 commits ahead of `main`, `main` has **not** moved since it branched (0 behind). No reviews yet, no comments, and **no CI** (no `.github/workflows` on either branch — the parity harness is local-only).
+This is what makes a no-rewrite admin interface viable. Content on `main` is not uniformly hardcoded — a large share of it already flows through **`js/translations.js`**:
 
-What it establishes:
+- **`TRANSLATIONS`** — 114 keyed strings (en + zh, key sets identical): nav labels, home hero/stats/about/why-choose, contact page, footer. Applied at runtime by `applyTranslations('en')` in `main.js`, which swaps `el.innerHTML` for every `[data-i18n]` element.
+- **`SERVICE_TRANSLATIONS`** — 9 services × `{hero_tag, title, sub, lead, features[]}`. Every `services/*.html` page has a small inline script that renders its hero, lead paragraphs, and feature list from this object at runtime.
 
-- **Astro 5.18, `output: 'static'`** — the deployed site remains fully static; no runtime server for pages.
-- **Content collections as the editor surface.** The 9 service pages are generated from `src/content/services/*.md` (front-matter + markdown body), validated by a Zod schema in `src/content.config.ts`. This is the foundation the admin interface sits on.
-- **Visual parity harness** (pytest + Playwright) comparing built DOM against `static-prototype/` (the approved design, kept in-tree as the reference). This is the design-safety gate.
-- **`contact-api/`** — a small Express + Resend service replacing the dead Formspree wiring, with honeypot, validation, and a 503 fallback until `RESEND_API_KEY` is set.
-- **`.do/app.yaml`** targeting the production domains (`securetours.com.au` / `www`) as a static site built from **branch `feature/astro`** plus the `contact-api` service (`/api` route, Sydney region). Note: the app is still named `secure-tours-zensical` (leftover from the abandoned PR #3 attempt).
-- The PR names **Sveltia CMS integration as the next task ("#56")** — that reference doesn't resolve to anything in this repo (issues are empty, PRs stop at #4); it presumably points at an external tracker and should be re-anchored to a real ticket.
+Coverage today (count of `data-i18n` bindings per page):
 
-The abandoned alternative (PR #3, Zensical/MkDocs) was closed for insufficient layout fidelity — the Astro direction is the settled one.
+| Well covered | Zero coverage (fully hardcoded HTML) |
+|---|---|
+| `index.html` (65), `contact.html` (34), `about.html` (34), all 9 `services/*.html` (13–20 each + `SERVICE_TRANSLATIONS`), `services/index.html` (20) | `resources.html`, `event-solutions.html`, `articles.html`, `articles/*.html` (5 pages), `404.html` |
 
-### Deliberate content decisions already made on the Astro branch
+So the seam we need — **content as data, design as code** — already exists for the home page, about, contact, and all nine service pages. The admin interface job is to (a) turn that data into files a CMS can edit, and (b) progressively widen the seam to the hardcoded pages.
 
-- The JS language toggle (`en`/`zh`) is gone; Mandarin survives as downloadable PDFs on Resources plus "languages we support" copy. Consistent with the earlier TOU-133 "remove lang selector" decision — flagging so it's confirmed, not accidental.
-- Service-page FAQs exist in the schema but are commented out in the markdown pending real answers from the client.
+### Two problems with the current mechanism to fix along the way
+
+1. **`translations.js` is code, not data.** It's a JS source file with string-escaping rules; a non-technical editor (or a CMS) shouldn't write JS.
+2. **Content only appears via JavaScript at runtime.** The inline HTML holds default copy that `applyTranslations` overwrites on load. If content is edited only in the data layer, the raw HTML drifts stale — crawlers and no-JS visitors see old copy. (The service-page hero/lead/features are worse: empty placeholders until JS runs.)
+
+Both are fixed by one small build step (Step 2 below) — a script, not a framework.
 
 ---
 
 ## 2. The admin interface: recommendation
 
-**Sveltia CMS on top of the Astro content collections** — confirming the direction already named in PR #4. Rationale:
+**Sveltia CMS editing JSON content files, with a tiny Node build script that bakes the content into the existing HTML at deploy time.** The HTML pages stay exactly as they are — they become the templates. No SSG, no components, no rewrite.
 
-- **Git-based, no backend.** Sveltia is a single static admin page (`/admin`) that commits directly to GitHub. No database, no CMS server to run or patch; the site stays a static build. Content edits are commits — full history, trivial rollback, and they flow through the same build pipeline as code.
-- **Design safety is structural, not behavioural.** The admin edits only the fields the CMS config exposes (title, lead, features list, etc.). Layout lives in `.astro` components the CMS never touches. Three independent guards:
-  1. **Zod schema** in `content.config.ts` — a malformed edit fails the build.
-  2. **DO App Platform semantics** — a failed build does not deploy; the last good version stays live. A bad edit can never take the site down.
-  3. **Parity harness in CI** (to be added, step 2 below) — catches structural drift.
-- **The alternative paths are worse for this site**: Decap CMS (same architecture, less maintained, weaker UX), a hosted CMS (Contentful/Sanity — monthly cost, content leaves git, overkill for ~20 pages), or a custom admin app (build + maintain burden nobody wants for a marketing site).
+Why this shape:
 
-**One real prerequisite: authentication.** Sveltia's GitHub backend needs an OAuth flow — this is the only server-ish piece:
+- **Git-based, no backend.** Sveltia CMS is a single static admin page (`/admin`) that commits directly to GitHub. No database, no CMS server; edits are commits — full history, trivial rollback, and they flow through the same deploy pipeline as code.
+- **Design safety is structural.** The admin edits only values in JSON files. Layout, classes (including the fragile `.reveal` animation classes), nav, and footer live in HTML/CSS the CMS never touches. A content edit *cannot* change markup structure.
+- **It reuses the site's own mechanism.** The build script does at build time exactly what `main.js` already does at runtime: find `[data-i18n]`, substitute the keyed string; render the service hero/lead/features blocks. Behaviour is already specified by working code — the script mirrors it.
+- **Deploy gate.** DO App Platform static sites accept a `build_command`. If the build script fails (malformed JSON, unknown key, missing field), the deploy fails and **the last good version stays live**. A bad edit can never take the site down.
 
-- Register a **GitHub OAuth App** and deploy **`sveltia-cms-auth`** (the tiny token-exchange endpoint). It ships as a Cloudflare Worker (free tier is fine); alternatively it can be run as a second small service on the existing DO app alongside `contact-api` to keep infrastructure in one place.
-- The admin needs a **GitHub account added as a collaborator** on `goodtune/securetours` (write access). Their edits land as their own commits — attributable and auditable.
+Alternatives considered:
+
+- **CloudCannon** — hosted CMS with visual editing over plain HTML; the closest "zero work" fit for this architecture, but paid SaaS (from ~US$49/mo), content workflow tied to a vendor. Worth a look if budget beats build effort; not recommended as default.
+- **Decap CMS** — same architecture as Sveltia, weaker maintenance and UX; Sveltia is its actively-developed successor.
+- **Contentful/Sanity etc.** — monthly cost, content leaves git, and still needs the same build step. Overkill for ~20 pages.
+- **Custom admin app** — build and maintain burden nobody wants for a marketing site.
+
+**One real prerequisite: authentication.** Sveltia's GitHub backend needs an OAuth token exchange — the only server-ish piece:
+
+- Register a **GitHub OAuth App** and deploy **`sveltia-cms-auth`** (a tiny token-exchange endpoint; ships as a Cloudflare Worker, free tier fine).
+- The admin needs a **GitHub account added as collaborator** on `goodtune/securetours` (write). They never see GitHub — only the CMS UI — but their edits land as their own attributable commits.
 
 **Publish flow decision** (recommend A):
 
-- **A. Commit straight to `main`, rely on the build gate.** Simplest mental model for a non-technical admin: save → live in ~2 minutes, or (on schema failure) nothing changes. Recommended given guards 1–3 above.
-- **B. Commit to a `content` branch, auto-PR to `main`.** Adds a human review step but requires someone to merge every wording tweak — friction that tends to kill CMS adoption. Keep as fallback if A proves too loose.
+- **A. Commit straight to `main`; rely on the build gate.** Save → live in a couple of minutes, or (on validation failure) nothing changes. Simplest mental model for a non-technical admin.
+- **B. CMS commits to a `content` branch; staging app deploys that branch for preview; a person merges to `main`.** Real preview + review, at the cost of a merge step per wording tweak. Viable later if A proves too loose.
+
+**Honest scope statement:** with this model the admin edits *copy on existing pages* — headings, paragraphs, feature lists, service descriptions, contact details. Creating new pages, changing navigation, or altering layout stays developer work. That is the "safely without blowing up the site design" contract.
 
 ---
 
 ## 3. Sequenced next steps
 
-### Step 0 — Review and merge PR #4 (blocker for everything)
+### Step 0 — Housekeeping from the rewrite decision
 
-The admin interface targets the Astro content collections, so nothing ships until the rewrite lands. Pre-merge checklist:
+- [ ] PR #4 closed (done). Archive or delete `feature/astro` and `feature/zensical` branches so nobody builds on them.
+- [ ] Nothing needs salvaging for this plan; two ideas from that branch are worth borrowing later if needs grow (Playwright layout-regression checks; a first-party contact API).
 
-- [ ] Review + client sign-off on the built site (the parity harness is the evidence).
-- [ ] Confirm the zh-toggle removal is an accepted decision.
-- [ ] Rename the DO app in `.do/app.yaml` (`secure-tours-zensical` → e.g. `secure-tours`).
-- [ ] Merge. Then immediately change `.do/app.yaml` `branch: feature/astro` → `branch: main` (both components) — as written, post-merge pushes to `main` would not deploy.
+### Step 1 — Bring the deployment under version control
 
-### Step 1 — Align deployments with the repo
+- [ ] Export the current DO app spec (dashboard → app → Settings → App Spec, or `doctl apps spec get`) and commit it as `.do/app.yaml`. Infra changes become reviewable, and the build step in Step 2 is a one-line diff instead of dashboard clicking.
+- [ ] Document which apps/branches serve staging (`securetours.staging-site.au`) and production, and what `securetours.com.au` currently points at.
 
-- [ ] Point the **staging** app (`securetours.staging-site.au`) at `main` building the Astro site; verify end-to-end (build, routes, 404, downloads).
-- [ ] Set the real `RESEND_API_KEY` in the DO dashboard (encrypted env var on `contact-api`); verify DKIM/SPF for `noreply@securetours.com.au` in Resend; test the contact form. This also fixes the currently-dead form.
-- [ ] Production cutover of `securetours.com.au`/`www` per the domains block in `app.yaml` (DNS/zone timing to be scheduled with the client).
+### Step 2 — Content becomes data + a build step (the enabling move)
 
-### Step 2 — CI as the safety net (before the admin gets keys)
+No visual change; pure refactor of where content lives:
 
-- [ ] GitHub Actions workflow on PRs and pushes to `main`: `npm ci && npm run build` + the pytest/Playwright parity harness.
-- [ ] Branch protection on `main` requiring the build check. (If publish flow A is chosen, require only the build — the harness can stay advisory on content-only commits so a slow check doesn't block copy edits; revisit once timings are known.)
-- [ ] Optional: `@astrojs/sitemap` so the sitemap stops being hand-maintained — one less thing content edits can silently break.
+- [ ] Convert `js/translations.js` into JSON under `content/`: e.g. `content/site.en.json`, `content/site.zh.json` (the 114 `TRANSLATIONS` keys) and `content/services/*.en.json` (+ `.zh.json`) for the 9 `SERVICE_TRANSLATIONS` entries.
+- [ ] Write `scripts/build.js` (Node, cheerio or similar — a dependency, not a framework) that copies the site into `dist/` and:
+  1. **Regenerates `js/translations.js`** from the JSON, so runtime behaviour is byte-for-byte unchanged.
+  2. **Bakes the `en` content into the HTML** — substitutes every `[data-i18n]` element's innerHTML and renders the service hero/lead/features blocks — fixing the stale-HTML/no-JS/SEO problem as a side effect.
+  3. **Fails loudly** on malformed JSON, a `data-i18n` key with no JSON entry, en/zh key-set mismatch, or a missing service field. This is the schema gate.
+- [ ] DO app: set `build_command: npm ci && node scripts/build.js`, `output_dir: dist` (roll out on staging first).
+- [ ] Escape values as text by default when baking; keep an explicit allowlist of keys permitted to carry markup (e.g. `hero_title` with its `<em>`), so a CMS edit can't inject broken markup site-wide.
 
-### Step 3 — Sveltia CMS integration (the admin interface itself)
+### Step 3 — CI before the admin gets keys
 
-- [ ] `public/admin/index.html` (loads Sveltia) + `public/admin/config.yml`.
-- [ ] Model the **services** collection in `config.yml` mirroring the Zod schema: string/text widgets for `title`, `meta_description`, `hero_tag`, `hero_sub`, `lead`; list-of-object widget for `features` (`icon`, `text`) and `faqs`; object widget for `home_card` and `cta`; markdown body for the "How It Works" prose. Keep `order`, `coming_soon`, `related_services` exposed but clearly labelled.
-- [ ] Register the GitHub OAuth App; deploy `sveltia-cms-auth` (Cloudflare Worker, or DO service next to `contact-api`); wire `base_url` in `config.yml`.
-- [ ] Add the admin as a repo collaborator; walk through login → edit → save → auto-deploy → rollback (revert commit) once, together.
-- [ ] Ticket this properly to replace the dangling "#56" reference in PR #4's description.
+- [ ] GitHub Actions on PRs and pushes to `main`: run `node scripts/build.js` (which validates everything above). Fast — seconds, not minutes.
+- [ ] Branch protection on `main` requiring that check.
+- [ ] Optional: Playwright smoke screenshots of key pages as an artifact — a cheap eyeball diff, borrowing the idea (not the code) from the closed rewrite.
 
-### Step 4 — Widen the editable surface (incremental, schema-first)
+### Step 4 — Sveltia CMS integration (the admin interface itself)
 
-Each of these follows the same recipe — extract to a content collection with a Zod schema first, then expose it in `config.yml`:
+- [ ] Add `admin/index.html` (loads Sveltia from CDN) + `admin/config.yml`.
+- [ ] Model collections over the JSON files: a "Site copy" file collection for `content/site.en.json` grouped by page (Home, About, Contact, Nav/Footer) using string/text widgets; a "Services" folder collection over `content/services/*.en.json` with fields `title`, `hero_tag`, `sub`, `lead` (text), `features` (list of strings). Label fields in plain English ("Home page — main headline"), not key names.
+- [ ] Register the GitHub OAuth App; deploy `sveltia-cms-auth` (Cloudflare Worker); wire it in `config.yml`.
+- [ ] Add the admin as repo collaborator; walk through login → edit → save → auto-deploy → rollback (revert commit) once, together.
+- [ ] Decide zh handling: expose the `.zh.json` files as a second collection if the admin maintains Mandarin copy, or leave zh developer-maintained (the language selector was removed in TOU-133; zh is currently dormant).
 
-- [ ] **Articles/case studies** (currently 6 bespoke `.astro` pages) → an `articles` collection.
-- [ ] **FAQs** — already schema'd; once the client supplies answers, uncomment and let them own the copy via the CMS.
-- [ ] **Resources/downloads** — a `downloads` collection (title, language, file) with file uploads to `public/assets/downloads/`.
-- [ ] **Site globals** — phone number, enquiry email, footer copy — as a singleton data file, so contact details stop being hardcoded in components.
-- [ ] Home/about hero copy last, and conservatively: the more layout-adjacent the field, the more it stays code.
+### Step 5 — Widen the editable surface (incremental, page by page)
 
-### Step 5 — Retire scaffolding (later)
+Same recipe each time — add `data-i18n` keys (or a small render block) to a hardcoded page, move its copy into JSON, expose in the CMS config:
 
-- [ ] Once the client has signed off the Astro build in production, decide the future of `static-prototype/` + the parity harness: keep as the design contract (recommended for now — it's what makes CMS-era changes verifiable), revisit after the CMS has been in use for a while.
+- [ ] `event-solutions.html` and `resources.html` — currently zero coverage; likely the most-edited marketing pages.
+- [ ] `articles.html` hub — consider driving the article *cards* (title, blurb, link) from a JSON list so the admin can reorder/retitle; article pages themselves stay developer work.
+- [ ] Contact details (phone number, email) as content keys — they appear on many pages and are exactly what a company admin wants to self-serve.
+- [ ] Keep the sitemap developer-owned (the admin can't create pages in this model, so hand-maintained `sitemap.xml` stays accurate by construction).
+
+### Step 6 — Fix the contact form (independent, do anytime)
+
+- [ ] Create the real Formspree form and replace the `FORMSPREE_FORM_ID` placeholder in `js/main.js` — one line, no architecture change. (If Formspree is unwanted, a small first-party endpoint like the closed PR's Resend service is the fallback; bigger lift.)
 
 ---
 
-## 4. Open questions / decisions needed
+## 4. Risks and mitigations
 
-1. **Publish flow A or B** (direct-to-`main` vs. PR-per-edit)? Recommendation: A.
-2. **Where does `sveltia-cms-auth` run** — Cloudflare Worker (free, Sveltia's reference deployment) or a third component on the DO app (single-vendor)?
-3. **Does the admin have / want a GitHub account?** Required for Sveltia's auth model; they never see GitHub itself, only the CMS UI.
-4. **What does "#56" in PR #4 refer to?** Needs re-anchoring to a real ticket (TOU-###?) so the CMS work is tracked.
-5. **Production cutover timing** for `securetours.com.au` — DNS zone changes need scheduling with whoever controls the domain.
+| Risk | Mitigation |
+|---|---|
+| Admin enters malformed content | JSON edited via CMS widgets (not raw text); build script validates; failed build ≠ failed site |
+| Content injected as HTML (`innerHTML`) | Escape-by-default at bake time; explicit allowlist for the few markup-bearing keys |
+| Copy looks wrong even though build passed | Publish flow B (content branch + staging preview) is the upgrade path; start with A + easy revert |
+| en/zh drift | Build fails on key-set mismatch (today they're identical at 114 keys — keep it that way) |
+| `.reveal` animation trap (elements stuck invisible) | Admin never touches classes or markup — content edits structurally can't introduce it |
+| Duplicated nav/footer across 22 pages | Out of scope for the admin interface (developer concern); the build script gives us a natural place to add shared-partial injection later *if* we ever want it |
+
+---
+
+## 5. Open questions / decisions needed
+
+1. **Publish flow A or B?** Recommendation: A (direct to `main`, build-gated), with B as the later upgrade.
+2. **Where does `sveltia-cms-auth` run** — Cloudflare Worker (free, reference deployment) or somewhere already in use?
+3. **Does the admin have / want a GitHub account?** Required for Sveltia's auth; they only ever see the CMS UI.
+4. **Is zh content live or dormant?** The selector was removed in TOU-133 and `main.js` hardcodes `'en'`. Decide whether the CMS exposes zh or it stays developer-maintained.
+5. **Formspree vs first-party contact endpoint** for Step 6.
+6. **Production domain state** — confirm what `securetours.com.au` points at today so Step 1's app spec capture covers both staging and production.

--- a/plans/admin-interface-plan.md
+++ b/plans/admin-interface-plan.md
@@ -10,14 +10,14 @@
 - **Astro 5.18, fully static output** on `main`: 14 page sources + `services/[slug].astro` generating 9 service pages from `src/content/services/*.md` (front-matter validated by the Zod schema in `src/content.config.ts`). **This markdown collection is the editor surface.**
 - **`contact-api/`** (Express + Resend) deployed as a second DO component at `/api`; `/api/health` is live.
 - **Parity harness** (`tests/`, pytest + Playwright) comparing built DOM to `static-prototype/` — the customer-approved design contract. Local-only today; no CI exists.
-- **DO App Platform** (app id `9e902f6a…`, behind Cloudflare) serving `securetours.com.au` / `www`, spec in `.do/app.yaml`.
+- **DO App Platform** (app id `9e902f6a…`, behind Cloudflare) serving `securetours.com.au` / `www`. Deployment is managed in the DO dashboard; the checked-in `.do/app.yaml` is **not** used to deploy.
 
-### Known issues on the baseline (carry onto the admin branch)
+### Known issues on the baseline (fix on the admin branch — decisions confirmed)
 
-1. `.do/app.yaml` still says `branch: feature/astro` on both components and the app is still named `secure-tours-zensical` — update to `main` / a proper name once the dashboard repoint is done, so repo and dashboard agree.
+1. **Delete `.do/app.yaml`** — it isn't used for deployment and is stale on both counts (`branch: feature/astro`, app name `secure-tours-zensical`), so it's misleading. After the dashboard repoint, keep a fresh spec export (`doctl apps spec get`) outside the repo as disaster-recovery reference.
 2. **`robots.txt` is not served** (it sits at repo root, not `public/`) and **there is no `sitemap.xml`** — both 404 in production. Fix: move `robots.txt` into `public/`, add `@astrojs/sitemap`, reference it from robots.txt.
-3. Confirm `RESEND_API_KEY` is a real key in the DO dashboard (`/api/health` returning ok does not prove email sends).
-4. `tmp/` scratch dir is tracked; harmless, tidy sometime.
+3. `RESEND_API_KEY` — confirmed real in production. Staging will not run `contact-api` at all (see §3).
+4. **Untrack `tmp/`** (add to `.gitignore`) as part of this work.
 
 ---
 
@@ -46,7 +46,7 @@ Work happens on a long-lived branch (working name `feature/admin-cms`) deployed 
 Staging specifics to get right:
 
 - **Sveltia `backend.branch`** must point at the staging branch while on staging, and at `main` in production. Drive it from an env var at build time so the same code deploys to both.
-- Staging's `contact-api` (if deployed at all) keeps the placeholder Resend key — the 503 fallback prevents test emails. Cheaper option: staging deploys the static site only.
+- **Staging is static-only** (decided): no `contact-api` component, no running-app cost. Consequence: the contact form on staging has no `/api/contact` endpoint and will show its failure message — acceptable; test the form on production.
 - The OAuth callback points at the auth helper, not the site, so one OAuth App + one `sveltia-cms-auth` serves both domains (list both in its allowed origins).
 - While staging is live, the admin's CMS edits land on the staging branch and arrive in production with the final merge. Avoid parallel content edits on `main` during that window, or merge them across promptly.
 - Keep the branch rebased on `main` regularly.
@@ -59,7 +59,7 @@ Staging specifics to get right:
 
 - [x] Merge `feature/astro` → `main` (`--no-ff`, empty diff verified).
 - [ ] Repoint the DO app components to `main` (dashboard — Gary). Verify a push to `main` triggers a deploy and the site is unchanged.
-- [ ] First commits on the admin branch: fix `.do/app.yaml` (branch → `main`, app name), move `robots.txt` to `public/`, add `@astrojs/sitemap`.
+- [ ] First commits on the admin branch: delete `.do/app.yaml`, move `robots.txt` to `public/`, add `@astrojs/sitemap`, untrack `tmp/`.
 - [ ] Delete `feature/astro` and `feature/zensical` **only after** the repoint is confirmed.
 
 ### Step 1 — CI before the admin gets keys

--- a/plans/admin-interface-plan.md
+++ b/plans/admin-interface-plan.md
@@ -1,146 +1,98 @@
-# Admin interface — review and plan (build on the existing static site)
+# Admin interface — plan (on the Astro production baseline)
 
-**Date:** 2026-07-08
-**Decision context:** The Astro rewrite (PR #4) has been closed and will not be used. The plan below layers a safe content-editing interface **on top of the existing static HTML site on `main`** — no framework, no rewrite.
-
----
-
-## 1. Where things stand today
-
-### Deployed state
-
-- `main` is the customer-approved static site: 22 standalone HTML pages, duplicated nav/footer per page, `css/style.css` design system, `js/main.js` + `js/translations.js`. Deployed to DigitalOcean App Platform; staging at `securetours.staging-site.au`.
-- The DO app spec is **not in the repo** — the live configuration exists only in the DO dashboard.
-- The contact form is **non-functional**: `js/main.js:47` still carries the `FORMSPREE_FORM_ID` placeholder.
-- No CI of any kind — nothing runs on push.
-
-### The key finding: the site already has a content layer
-
-This is what makes a no-rewrite admin interface viable. Content on `main` is not uniformly hardcoded — a large share of it already flows through **`js/translations.js`**:
-
-- **`TRANSLATIONS`** — 114 keyed strings (en + zh, key sets identical): nav labels, home hero/stats/about/why-choose, contact page, footer. Applied at runtime by `applyTranslations('en')` in `main.js`, which swaps `el.innerHTML` for every `[data-i18n]` element.
-- **`SERVICE_TRANSLATIONS`** — 9 services × `{hero_tag, title, sub, lead, features[]}`. Every `services/*.html` page has a small inline script that renders its hero, lead paragraphs, and feature list from this object at runtime.
-
-Coverage today (count of `data-i18n` bindings per page):
-
-| Well covered | Zero coverage (fully hardcoded HTML) |
-|---|---|
-| `index.html` (65), `contact.html` (34), `about.html` (34), all 9 `services/*.html` (13–20 each + `SERVICE_TRANSLATIONS`), `services/index.html` (20) | `resources.html`, `event-solutions.html`, `articles.html`, `articles/*.html` (5 pages), `404.html` |
-
-So the seam we need — **content as data, design as code** — already exists for the home page, about, contact, and all nine service pages. The admin interface job is to (a) turn that data into files a CMS can edit, and (b) progressively widen the seam to the hardcoded pages.
-
-### Two problems with the current mechanism to fix along the way
-
-1. **`translations.js` is code, not data.** It's a JS source file with string-escaping rules; a non-technical editor (or a CMS) shouldn't write JS.
-2. **Content only appears via JavaScript at runtime.** The inline HTML holds default copy that `applyTranslations` overwrites on load. If content is edited only in the data layer, the raw HTML drifts stale — crawlers and no-JS visitors see old copy. (The service-page hero/lead/features are worse: empty placeholders until JS runs.)
-
-Both are fixed by one small build step (Step 2 below) — a script, not a framework.
+**Date:** 2026-07-10
+**Context:** The Astro build from `feature/astro` was found to be what actually serves `securetours.com.au` (verified byte-identical, 24/24 pages, against the branch HEAD build). `feature/astro` has therefore been merged into `main` (`--no-ff`, trees identical), and the DO app is being repointed from `feature/astro` to `main` — a content no-op. The admin interface is built on this baseline.
 
 ---
 
-## 2. The admin interface: recommendation
+## 1. Baseline after the merge
 
-**Sveltia CMS editing JSON content files, with a tiny Node build script that bakes the content into the existing HTML at deploy time.** The HTML pages stay exactly as they are — they become the templates. No SSG, no components, no rewrite.
+- **Astro 5.18, fully static output** on `main`: 14 page sources + `services/[slug].astro` generating 9 service pages from `src/content/services/*.md` (front-matter validated by the Zod schema in `src/content.config.ts`). **This markdown collection is the editor surface.**
+- **`contact-api/`** (Express + Resend) deployed as a second DO component at `/api`; `/api/health` is live.
+- **Parity harness** (`tests/`, pytest + Playwright) comparing built DOM to `static-prototype/` — the customer-approved design contract. Local-only today; no CI exists.
+- **DO App Platform** (app id `9e902f6a…`, behind Cloudflare) serving `securetours.com.au` / `www`, spec in `.do/app.yaml`.
 
-Why this shape:
+### Known issues on the baseline (carry onto the admin branch)
 
-- **Git-based, no backend.** Sveltia CMS is a single static admin page (`/admin`) that commits directly to GitHub. No database, no CMS server; edits are commits — full history, trivial rollback, and they flow through the same deploy pipeline as code.
-- **Design safety is structural.** The admin edits only values in JSON files. Layout, classes (including the fragile `.reveal` animation classes), nav, and footer live in HTML/CSS the CMS never touches. A content edit *cannot* change markup structure.
-- **It reuses the site's own mechanism.** The build script does at build time exactly what `main.js` already does at runtime: find `[data-i18n]`, substitute the keyed string; render the service hero/lead/features blocks. Behaviour is already specified by working code — the script mirrors it.
-- **Deploy gate.** DO App Platform static sites accept a `build_command`. If the build script fails (malformed JSON, unknown key, missing field), the deploy fails and **the last good version stays live**. A bad edit can never take the site down.
-
-Alternatives considered:
-
-- **CloudCannon** — hosted CMS with visual editing over plain HTML; the closest "zero work" fit for this architecture, but paid SaaS (from ~US$49/mo), content workflow tied to a vendor. Worth a look if budget beats build effort; not recommended as default.
-- **Decap CMS** — same architecture as Sveltia, weaker maintenance and UX; Sveltia is its actively-developed successor.
-- **Contentful/Sanity etc.** — monthly cost, content leaves git, and still needs the same build step. Overkill for ~20 pages.
-- **Custom admin app** — build and maintain burden nobody wants for a marketing site.
-
-**One real prerequisite: authentication.** Sveltia's GitHub backend needs an OAuth token exchange — the only server-ish piece:
-
-- Register a **GitHub OAuth App** and deploy **`sveltia-cms-auth`** (a tiny token-exchange endpoint; ships as a Cloudflare Worker, free tier fine).
-- The admin needs a **GitHub account added as collaborator** on `goodtune/securetours` (write). They never see GitHub — only the CMS UI — but their edits land as their own attributable commits.
-
-**Publish flow decision** (recommend A):
-
-- **A. Commit straight to `main`; rely on the build gate.** Save → live in a couple of minutes, or (on validation failure) nothing changes. Simplest mental model for a non-technical admin.
-- **B. CMS commits to a `content` branch; staging app deploys that branch for preview; a person merges to `main`.** Real preview + review, at the cost of a merge step per wording tweak. Viable later if A proves too loose.
-
-**Honest scope statement:** with this model the admin edits *copy on existing pages* — headings, paragraphs, feature lists, service descriptions, contact details. Creating new pages, changing navigation, or altering layout stays developer work. That is the "safely without blowing up the site design" contract.
+1. `.do/app.yaml` still says `branch: feature/astro` on both components and the app is still named `secure-tours-zensical` — update to `main` / a proper name once the dashboard repoint is done, so repo and dashboard agree.
+2. **`robots.txt` is not served** (it sits at repo root, not `public/`) and **there is no `sitemap.xml`** — both 404 in production. Fix: move `robots.txt` into `public/`, add `@astrojs/sitemap`, reference it from robots.txt.
+3. Confirm `RESEND_API_KEY` is a real key in the DO dashboard (`/api/health` returning ok does not prove email sends).
+4. `tmp/` scratch dir is tracked; harmless, tidy sometime.
 
 ---
 
-## 3. Sequenced next steps
+## 2. The admin interface: approach
 
-### Step 0 — Housekeeping from the rewrite decision
+**Sveltia CMS over the existing content collections.** A static `/admin` page that commits to GitHub — no database, no CMS server; edits are attributable, revertible commits that flow through the same build pipeline as code.
 
-- [ ] PR #4 closed (done). Archive or delete `feature/astro` and `feature/zensical` branches so nobody builds on them.
-- [ ] Nothing needs salvaging for this plan; two ideas from that branch are worth borrowing later if needs grow (Playwright layout-regression checks; a first-party contact API).
+Safety model (three independent guards):
 
-### Step 1 — Bring the deployment under version control
+1. **Zod schema** — a malformed edit fails `astro build`.
+2. **DO build gate** — a failed build never deploys; the last good version stays live.
+3. **Parity harness in CI** — catches structural/design drift.
 
-- [ ] Export the current DO app spec (dashboard → app → Settings → App Spec, or `doctl apps spec get`) and commit it as `.do/app.yaml`. Infra changes become reviewable, and the build step in Step 2 is a one-line diff instead of dashboard clicking.
-- [ ] Document which apps/branches serve staging (`securetours.staging-site.au`) and production, and what `securetours.com.au` currently points at.
+The admin edits *content fields* (titles, leads, features, FAQs, prose). Layout, components, nav, and CSS are never reachable from the CMS. New pages/routes stay developer work.
 
-### Step 2 — Content becomes data + a build step (the enabling move)
-
-No visual change; pure refactor of where content lives:
-
-- [ ] Convert `js/translations.js` into JSON under `content/`: e.g. `content/site.en.json`, `content/site.zh.json` (the 114 `TRANSLATIONS` keys) and `content/services/*.en.json` (+ `.zh.json`) for the 9 `SERVICE_TRANSLATIONS` entries.
-- [ ] Write `scripts/build.js` (Node, cheerio or similar — a dependency, not a framework) that copies the site into `dist/` and:
-  1. **Regenerates `js/translations.js`** from the JSON, so runtime behaviour is byte-for-byte unchanged.
-  2. **Bakes the `en` content into the HTML** — substitutes every `[data-i18n]` element's innerHTML and renders the service hero/lead/features blocks — fixing the stale-HTML/no-JS/SEO problem as a side effect.
-  3. **Fails loudly** on malformed JSON, a `data-i18n` key with no JSON entry, en/zh key-set mismatch, or a missing service field. This is the schema gate.
-- [ ] DO app: set `build_command: npm ci && node scripts/build.js`, `output_dir: dist` (roll out on staging first).
-- [ ] Escape values as text by default when baking; keep an explicit allowlist of keys permitted to carry markup (e.g. `hero_title` with its `<em>`), so a CMS edit can't inject broken markup site-wide.
-
-### Step 3 — CI before the admin gets keys
-
-- [ ] GitHub Actions on PRs and pushes to `main`: run `node scripts/build.js` (which validates everything above). Fast — seconds, not minutes.
-- [ ] Branch protection on `main` requiring that check.
-- [ ] Optional: Playwright smoke screenshots of key pages as an artifact — a cheap eyeball diff, borrowing the idea (not the code) from the closed rewrite.
-
-### Step 4 — Sveltia CMS integration (the admin interface itself)
-
-- [ ] Add `admin/index.html` (loads Sveltia from CDN) + `admin/config.yml`.
-- [ ] Model collections over the JSON files: a "Site copy" file collection for `content/site.en.json` grouped by page (Home, About, Contact, Nav/Footer) using string/text widgets; a "Services" folder collection over `content/services/*.en.json` with fields `title`, `hero_tag`, `sub`, `lead` (text), `features` (list of strings). Label fields in plain English ("Home page — main headline"), not key names.
-- [ ] Register the GitHub OAuth App; deploy `sveltia-cms-auth` (Cloudflare Worker); wire it in `config.yml`.
-- [ ] Add the admin as repo collaborator; walk through login → edit → save → auto-deploy → rollback (revert commit) once, together.
-- [ ] Decide zh handling: expose the `.zh.json` files as a second collection if the admin maintains Mandarin copy, or leave zh developer-maintained (the language selector was removed in TOU-133; zh is currently dormant).
-
-### Step 5 — Widen the editable surface (incremental, page by page)
-
-Same recipe each time — add `data-i18n` keys (or a small render block) to a hardcoded page, move its copy into JSON, expose in the CMS config:
-
-- [ ] `event-solutions.html` and `resources.html` — currently zero coverage; likely the most-edited marketing pages.
-- [ ] `articles.html` hub — consider driving the article *cards* (title, blurb, link) from a JSON list so the admin can reorder/retitle; article pages themselves stay developer work.
-- [ ] Contact details (phone number, email) as content keys — they appear on many pages and are exactly what a company admin wants to self-serve.
-- [ ] Keep the sitemap developer-owned (the admin can't create pages in this model, so hand-maintained `sitemap.xml` stays accurate by construction).
-
-### Step 6 — Fix the contact form (independent, do anytime)
-
-- [ ] Create the real Formspree form and replace the `FORMSPREE_FORM_ID` placeholder in `js/main.js` — one line, no architecture change. (If Formspree is unwanted, a small first-party endpoint like the closed PR's Resend service is the fallback; bigger lift.)
+**Prerequisite — auth:** Sveltia's GitHub backend needs an OAuth token exchange:
+- Register a GitHub OAuth App; deploy `sveltia-cms-auth` (reference deployment is a free Cloudflare Worker; a third small DO component is the single-vendor alternative).
+- The admin gets a GitHub account added as collaborator (write). They only ever see the CMS UI.
 
 ---
 
-## 4. Risks and mitigations
+## 3. Delivery model (agreed)
 
-| Risk | Mitigation |
-|---|---|
-| Admin enters malformed content | JSON edited via CMS widgets (not raw text); build script validates; failed build ≠ failed site |
-| Content injected as HTML (`innerHTML`) | Escape-by-default at bake time; explicit allowlist for the few markup-bearing keys |
-| Copy looks wrong even though build passed | Publish flow B (content branch + staging preview) is the upgrade path; start with A + easy revert |
-| en/zh drift | Build fails on key-set mismatch (today they're identical at 114 keys — keep it that way) |
-| `.reveal` animation trap (elements stuck invisible) | Admin never touches classes or markup — content edits structurally can't introduce it |
-| Duplicated nav/footer across 22 pages | Out of scope for the admin interface (developer concern); the build script gives us a natural place to add shared-partial injection later *if* we ever want it |
+Work happens on a long-lived branch (working name `feature/admin-cms`) deployed as a **staging site** (second DO app, its own subdomain). When accepted, merge to `main` → production.
+
+Staging specifics to get right:
+
+- **Sveltia `backend.branch`** must point at the staging branch while on staging, and at `main` in production. Drive it from an env var at build time so the same code deploys to both.
+- Staging's `contact-api` (if deployed at all) keeps the placeholder Resend key — the 503 fallback prevents test emails. Cheaper option: staging deploys the static site only.
+- The OAuth callback points at the auth helper, not the site, so one OAuth App + one `sveltia-cms-auth` serves both domains (list both in its allowed origins).
+- While staging is live, the admin's CMS edits land on the staging branch and arrive in production with the final merge. Avoid parallel content edits on `main` during that window, or merge them across promptly.
+- Keep the branch rebased on `main` regularly.
 
 ---
 
-## 5. Open questions / decisions needed
+## 4. Sequenced steps
 
-1. **Publish flow A or B?** Recommendation: A (direct to `main`, build-gated), with B as the later upgrade.
-2. **Where does `sveltia-cms-auth` run** — Cloudflare Worker (free, reference deployment) or somewhere already in use?
-3. **Does the admin have / want a GitHub account?** Required for Sveltia's auth; they only ever see the CMS UI.
-4. **Is zh content live or dormant?** The selector was removed in TOU-133 and `main.js` hardcodes `'en'`. Decide whether the CMS exposes zh or it stays developer-maintained.
-5. **Formspree vs first-party contact endpoint** for Step 6.
-6. **Production domain state** — confirm what `securetours.com.au` points at today so Step 1's app spec capture covers both staging and production.
+### Step 0 — Cutover hygiene (this week)
+
+- [x] Merge `feature/astro` → `main` (`--no-ff`, empty diff verified).
+- [ ] Repoint the DO app components to `main` (dashboard — Gary). Verify a push to `main` triggers a deploy and the site is unchanged.
+- [ ] First commits on the admin branch: fix `.do/app.yaml` (branch → `main`, app name), move `robots.txt` to `public/`, add `@astrojs/sitemap`.
+- [ ] Delete `feature/astro` and `feature/zensical` **only after** the repoint is confirmed.
+
+### Step 1 — CI before the admin gets keys
+
+- [ ] GitHub Actions on PRs + pushes to `main`: `npm ci && npm run build`, then the pytest/Playwright parity harness.
+- [ ] Branch protection on `main` requiring the build check (harness advisory at first if it proves slow on content-only commits).
+
+### Step 2 — Sveltia CMS integration
+
+- [ ] `public/admin/index.html` (loads Sveltia) + `public/admin/config.yml`.
+- [ ] Model the **services** collection mirroring the Zod schema: strings for `title`, `meta_description`, `hero_tag`, `hero_sub`; text for `lead`; list-of-object for `features` (`icon`, `text`) and `faqs`; objects for `home_card`, `cta`; markdown body. Expose `order`, `coming_soon`, `related_services` with clear labels. Plain-English field labels throughout.
+- [ ] GitHub OAuth App + `sveltia-cms-auth`; wire `base_url` in `config.yml`.
+- [ ] Stand up the staging DO app on the admin branch; walk the admin through login → edit → save → deploy → rollback once, together.
+
+### Step 3 — Widen the editable surface (schema-first, incremental)
+
+- [ ] **Articles/case studies** — currently 6 bespoke `.astro` pages; extract an `articles` collection (the biggest win after services).
+- [ ] **FAQs** — schema exists; when the client supplies answers, they own the copy via the CMS.
+- [ ] **Resources/downloads** — a `downloads` collection with file uploads to `public/assets/downloads/`.
+- [ ] **Site globals** — phone, enquiry email, footer copy as a singleton data file (they're currently hardcoded in components).
+- [ ] Home/about hero copy last and conservatively — the more layout-adjacent, the more it stays code.
+
+### Step 4 — Later
+
+- [ ] Revisit `static-prototype/` + harness once the CMS has been in use (keep for now — it's the design contract that makes CMS-era changes verifiable).
+- [ ] Publish-flow upgrade if needed: CMS commits to a content branch + auto-PR instead of direct-to-`main`.
+
+---
+
+## 5. Open decisions
+
+1. **Publish flow:** direct-to-`main` with the build gate (recommended) vs. PR-per-edit.
+2. **`sveltia-cms-auth` hosting:** Cloudflare Worker (free, reference) vs. third DO component.
+3. **Admin's GitHub account** — needed as collaborator; confirm they have/want one.
+4. **Staging domain** for the second DO app (e.g. `staging.securetours.com.au`).
+5. **zh/Mandarin:** the rewrite dropped the language toggle (Mandarin remains as PDFs). Confirm this is accepted; if zh pages ever return, it becomes an i18n content-collection design question.

--- a/plans/admin-interface-plan.md
+++ b/plans/admin-interface-plan.md
@@ -1,0 +1,115 @@
+# Admin interface — review and plan
+
+**Date:** 2026-07-05
+**Scope:** How the company admin gets a safe content-editing interface, what is already in flight, what deployments look like today, and the sequenced steps to get there.
+
+---
+
+## 1. Where things stand today
+
+### Deployed state (production/staging)
+
+- **`main`** is the customer-approved static HTML prototype: 22 bespoke pages, duplicated nav/footer in every file, `js/translations.js` as the JS-injected content source, hand-maintained `sitemap.xml`. Deployed to DigitalOcean App Platform; staging at `securetours.staging-site.au`.
+- The DO app spec for the *current* static deployment is **not in the repo** — `main` has no `.do/app.yaml`. The live app configuration exists only in the DO dashboard (click-ops).
+- The contact form on `main` is **non-functional**: `js/main.js:47` still has the `FORMSPREE_FORM_ID` placeholder.
+- There is nothing an admin can safely edit here. Every content change means hand-editing HTML duplicated across ~22 files (plus `translations.js`), which is exactly the "blow up the site design" risk we want to remove.
+
+### In flight: PR #4 — Astro rewrite (`feature/astro`, TOU-159)
+
+Open, mergeable-clean, 27 commits ahead of `main`, `main` has **not** moved since it branched (0 behind). No reviews yet, no comments, and **no CI** (no `.github/workflows` on either branch — the parity harness is local-only).
+
+What it establishes:
+
+- **Astro 5.18, `output: 'static'`** — the deployed site remains fully static; no runtime server for pages.
+- **Content collections as the editor surface.** The 9 service pages are generated from `src/content/services/*.md` (front-matter + markdown body), validated by a Zod schema in `src/content.config.ts`. This is the foundation the admin interface sits on.
+- **Visual parity harness** (pytest + Playwright) comparing built DOM against `static-prototype/` (the approved design, kept in-tree as the reference). This is the design-safety gate.
+- **`contact-api/`** — a small Express + Resend service replacing the dead Formspree wiring, with honeypot, validation, and a 503 fallback until `RESEND_API_KEY` is set.
+- **`.do/app.yaml`** targeting the production domains (`securetours.com.au` / `www`) as a static site built from **branch `feature/astro`** plus the `contact-api` service (`/api` route, Sydney region). Note: the app is still named `secure-tours-zensical` (leftover from the abandoned PR #3 attempt).
+- The PR names **Sveltia CMS integration as the next task ("#56")** — that reference doesn't resolve to anything in this repo (issues are empty, PRs stop at #4); it presumably points at an external tracker and should be re-anchored to a real ticket.
+
+The abandoned alternative (PR #3, Zensical/MkDocs) was closed for insufficient layout fidelity — the Astro direction is the settled one.
+
+### Deliberate content decisions already made on the Astro branch
+
+- The JS language toggle (`en`/`zh`) is gone; Mandarin survives as downloadable PDFs on Resources plus "languages we support" copy. Consistent with the earlier TOU-133 "remove lang selector" decision — flagging so it's confirmed, not accidental.
+- Service-page FAQs exist in the schema but are commented out in the markdown pending real answers from the client.
+
+---
+
+## 2. The admin interface: recommendation
+
+**Sveltia CMS on top of the Astro content collections** — confirming the direction already named in PR #4. Rationale:
+
+- **Git-based, no backend.** Sveltia is a single static admin page (`/admin`) that commits directly to GitHub. No database, no CMS server to run or patch; the site stays a static build. Content edits are commits — full history, trivial rollback, and they flow through the same build pipeline as code.
+- **Design safety is structural, not behavioural.** The admin edits only the fields the CMS config exposes (title, lead, features list, etc.). Layout lives in `.astro` components the CMS never touches. Three independent guards:
+  1. **Zod schema** in `content.config.ts` — a malformed edit fails the build.
+  2. **DO App Platform semantics** — a failed build does not deploy; the last good version stays live. A bad edit can never take the site down.
+  3. **Parity harness in CI** (to be added, step 2 below) — catches structural drift.
+- **The alternative paths are worse for this site**: Decap CMS (same architecture, less maintained, weaker UX), a hosted CMS (Contentful/Sanity — monthly cost, content leaves git, overkill for ~20 pages), or a custom admin app (build + maintain burden nobody wants for a marketing site).
+
+**One real prerequisite: authentication.** Sveltia's GitHub backend needs an OAuth flow — this is the only server-ish piece:
+
+- Register a **GitHub OAuth App** and deploy **`sveltia-cms-auth`** (the tiny token-exchange endpoint). It ships as a Cloudflare Worker (free tier is fine); alternatively it can be run as a second small service on the existing DO app alongside `contact-api` to keep infrastructure in one place.
+- The admin needs a **GitHub account added as a collaborator** on `goodtune/securetours` (write access). Their edits land as their own commits — attributable and auditable.
+
+**Publish flow decision** (recommend A):
+
+- **A. Commit straight to `main`, rely on the build gate.** Simplest mental model for a non-technical admin: save → live in ~2 minutes, or (on schema failure) nothing changes. Recommended given guards 1–3 above.
+- **B. Commit to a `content` branch, auto-PR to `main`.** Adds a human review step but requires someone to merge every wording tweak — friction that tends to kill CMS adoption. Keep as fallback if A proves too loose.
+
+---
+
+## 3. Sequenced next steps
+
+### Step 0 — Review and merge PR #4 (blocker for everything)
+
+The admin interface targets the Astro content collections, so nothing ships until the rewrite lands. Pre-merge checklist:
+
+- [ ] Review + client sign-off on the built site (the parity harness is the evidence).
+- [ ] Confirm the zh-toggle removal is an accepted decision.
+- [ ] Rename the DO app in `.do/app.yaml` (`secure-tours-zensical` → e.g. `secure-tours`).
+- [ ] Merge. Then immediately change `.do/app.yaml` `branch: feature/astro` → `branch: main` (both components) — as written, post-merge pushes to `main` would not deploy.
+
+### Step 1 — Align deployments with the repo
+
+- [ ] Point the **staging** app (`securetours.staging-site.au`) at `main` building the Astro site; verify end-to-end (build, routes, 404, downloads).
+- [ ] Set the real `RESEND_API_KEY` in the DO dashboard (encrypted env var on `contact-api`); verify DKIM/SPF for `noreply@securetours.com.au` in Resend; test the contact form. This also fixes the currently-dead form.
+- [ ] Production cutover of `securetours.com.au`/`www` per the domains block in `app.yaml` (DNS/zone timing to be scheduled with the client).
+
+### Step 2 — CI as the safety net (before the admin gets keys)
+
+- [ ] GitHub Actions workflow on PRs and pushes to `main`: `npm ci && npm run build` + the pytest/Playwright parity harness.
+- [ ] Branch protection on `main` requiring the build check. (If publish flow A is chosen, require only the build — the harness can stay advisory on content-only commits so a slow check doesn't block copy edits; revisit once timings are known.)
+- [ ] Optional: `@astrojs/sitemap` so the sitemap stops being hand-maintained — one less thing content edits can silently break.
+
+### Step 3 — Sveltia CMS integration (the admin interface itself)
+
+- [ ] `public/admin/index.html` (loads Sveltia) + `public/admin/config.yml`.
+- [ ] Model the **services** collection in `config.yml` mirroring the Zod schema: string/text widgets for `title`, `meta_description`, `hero_tag`, `hero_sub`, `lead`; list-of-object widget for `features` (`icon`, `text`) and `faqs`; object widget for `home_card` and `cta`; markdown body for the "How It Works" prose. Keep `order`, `coming_soon`, `related_services` exposed but clearly labelled.
+- [ ] Register the GitHub OAuth App; deploy `sveltia-cms-auth` (Cloudflare Worker, or DO service next to `contact-api`); wire `base_url` in `config.yml`.
+- [ ] Add the admin as a repo collaborator; walk through login → edit → save → auto-deploy → rollback (revert commit) once, together.
+- [ ] Ticket this properly to replace the dangling "#56" reference in PR #4's description.
+
+### Step 4 — Widen the editable surface (incremental, schema-first)
+
+Each of these follows the same recipe — extract to a content collection with a Zod schema first, then expose it in `config.yml`:
+
+- [ ] **Articles/case studies** (currently 6 bespoke `.astro` pages) → an `articles` collection.
+- [ ] **FAQs** — already schema'd; once the client supplies answers, uncomment and let them own the copy via the CMS.
+- [ ] **Resources/downloads** — a `downloads` collection (title, language, file) with file uploads to `public/assets/downloads/`.
+- [ ] **Site globals** — phone number, enquiry email, footer copy — as a singleton data file, so contact details stop being hardcoded in components.
+- [ ] Home/about hero copy last, and conservatively: the more layout-adjacent the field, the more it stays code.
+
+### Step 5 — Retire scaffolding (later)
+
+- [ ] Once the client has signed off the Astro build in production, decide the future of `static-prototype/` + the parity harness: keep as the design contract (recommended for now — it's what makes CMS-era changes verifiable), revisit after the CMS has been in use for a while.
+
+---
+
+## 4. Open questions / decisions needed
+
+1. **Publish flow A or B** (direct-to-`main` vs. PR-per-edit)? Recommendation: A.
+2. **Where does `sveltia-cms-auth` run** — Cloudflare Worker (free, Sveltia's reference deployment) or a third component on the DO app (single-vendor)?
+3. **Does the admin have / want a GitHub account?** Required for Sveltia's auth model; they never see GitHub itself, only the CMS UI.
+4. **What does "#56" in PR #4 refer to?** Needs re-anchoring to a real ticket (TOU-###?) so the CMS work is tracked.
+5. **Production cutover timing** for `securetours.com.au` — DNS zone changes need scheduling with whoever controls the domain.


### PR DESCRIPTION
## Summary

Adds `plans/admin-interface-plan.md` — the plan for the company admin's content-editing interface, now targeting the **Astro baseline that actually serves production**.

**Context:** the live `securetours.com.au` was verified to be the `feature/astro` build (24/24 pages byte-identical to the branch HEAD build, `contact-api` live at `/api`). `feature/astro` has been merged into `main` with `--no-ff` (empty diff verified) so `main` matches production; the DO app is being repointed to `main` as a no-op.

**The plan (short version):**

0. Cutover hygiene: repoint DO app to `main`; fix `.do/app.yaml` (`branch: feature/astro` → `main`, stale app name); fix live bugs found during verification — `robots.txt` 404s (sits at repo root, not `public/`) and `sitemap.xml` is missing.
1. CI (Astro build + the pytest/Playwright parity harness) + branch protection before the admin gets write access.
2. Sveltia CMS over `src/content/services/*.md` (`public/admin/` + `config.yml` mirroring the Zod schema, GitHub OAuth via `sveltia-cms-auth`, admin as collaborator).
3. Widen the surface schema-first: articles collection, FAQs, downloads, site globals.

Delivery model: a long-lived `feature/admin-cms` branch deployed as a second DO app (staging), merged to `main` when accepted — including the gotchas that setup implies (Sveltia `backend.branch` per environment, staging contact-api with placeholder key, shared OAuth helper, drift management).

Open decisions listed at the end: publish flow, OAuth helper hosting, admin GitHub account, staging domain, zh/Mandarin status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J5SrG53Q17Y9USGyrqq4EW